### PR TITLE
cypress defaults NODE_ENV to string “undefined”

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,3 +1,15 @@
-describe('page', () => {
-  it('works', () => {})
-})
+describe("exec environment", () => {
+  it("should not set NODE_ENV to `'undefined'`", () => {
+    cy
+      .exec("echo $NODE_ENV")
+      .its("stdout")
+      .should("eq", "");
+  });
+
+  it("should behave like this for NODE_ENV", () => {
+    cy
+      .exec("echo $RANDOM_UNDEFINED_VAR")
+      .its("stdout")
+      .should("eq", "");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Small project for quickly testing Cypress.io test runner",
   "scripts": {
-    "cypress:run": "cypress run",
-    "cypress:open": "cypress open",
+    "cypress:run": "unset -v NODE_ENV && cypress run",
+    "cypress:open": "unset -v NODE_ENV && cypress open",
     "cypress:verify": "cypress verify",
     "cypress:version": "cypress version",
     "list-videos": "ls -l cypress/videos",


### PR DESCRIPTION
PR-ing so CI builds.  Issue filed at https://github.com/cypress-io/cypress/issues/1223