### PR TITLE
cy.get("selector").contains(/'/) breaks

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,3 +1,6 @@
-describe('page', () => {
-  it('works', () => {})
-})
+describe("valid regexes containing an apostrophe", () => {
+  it("should not break contains", () => {
+    cy.visit("/index.html");
+    cy.get("p").contains(/shouldn't/);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <p>this is some text</p>
+    <p>we shouldn't have trouble selecting an apostrophe</p>
+  </body>
+</html>


### PR DESCRIPTION
pr-ing for ci. this is the example repo for https://github.com/cypress-io/cypress/issues/1322

the regex is concatenated into a single-quote-delimited selector expression but is not properly escaped

this is the error:
```
1) valid regexes containing an apostrophe should not break contains:
     Error: Syntax error, unrecognized expression: :not(script):contains('/shouldn't/'), [type='submit'][value~='/shouldn't/']
      at Function.Sizzle.error (http://localhost:52708/__cypress/runner/cypress_runner.js:17113:8)
      at Sizzle.tokenize (http://localhost:52708/__cypress/runner/cypress_runner.js:17770:11)
      at Function.Sizzle [as find] (http://localhost:52708/__cypress/runner/cypress_runner.js:16483:15)
      at jQuery.find (http://localhost:52708/__cypress/runner/cypress_runner.js:18437:11)
      at jQuery.fn.init (http://localhost:52708/__cypress/runner/cypress_runner.js:18554:32)
      at Object.$$ (http://localhost:52708/__cypress/runner/cypress_runner.js:61799:12)
      at getElements (http://localhost:52708/__cypress/runner/cypress_runner.js:57944:20)
      at tryCatcher (http://localhost:52708/__cypress/runner/cypress_runner.js:6268:23)
      at Function.Promise.attempt.Promise.try (http://localhost:52708/__cypress/runner/cypress_runner.js:3647:29)
      at resolveElements (http://localhost:52708/__cypress/runner/cypress_runner.js:57970:30)
      at Object.get (http://localhost:52708/__cypress/runner/cypress_runner.js:57978:9)
      at Object.now (http://localhost:52708/__cypress/runner/cypress_runner.js:62235:47)
      at resolveElements (http://localhost:52708/__cypress/runner/cypress_runner.js:58113:19)
      at tryCatcher (http://localhost:52708/__cypress/runner/cypress_runner.js:6268:23)
      at Function.Promise.attempt.Promise.try (http://localhost:52708/__cypress/runner/cypress_runner.js:3647:29)
      at Context.contains (http://localhost:52708/__cypress/runner/cypress_runner.js:58136:28)
      at Context.<anonymous> (http://localhost:52708/__cypress/runner/cypress_runner.js:62185:21)
      at http://localhost:52708/__cypress/runner/cypress_runner.js:61900:33
      at tryCatcher (http://localhost:52708/__cypress/runner/cypress_runner.js:6268:23)
      at Promise._settlePromiseFromHandler (http://localhost:52708/__cypress/runner/cypress_runner.js:4290:31)
      at Promise._settlePromise (http://localhost:52708/__cypress/runner/cypress_runner.js:4347:18)
      at Promise._settlePromiseCtx (http://localhost:52708/__cypress/runner/cypress_runner.js:4384:10)
```