### PR TITLE
WIP: do not merge: crash example

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Small project for quickly testing Cypress.io test runner",
   "scripts": {
-    "cypress:run": "cypress run",
+    "cypress:run": "node ./test",
     "cypress:open": "cypress open",
     "cypress:verify": "cypress verify",
     "cypress:version": "cypress version",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "devDependencies": {
     "@cypress/commit-message-install": "2.3.0",
+    "cypress": "3.2.0",
     "ok-file": "1.4.0"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,14 @@
+const cypress = require('cypress')
+cypress.run({
+  // this works fine
+  // spec: 'cypress/integration/spec.js'
+  // this crashes badly - hanging Cypress
+  spec: {}
+
+  /*
+    this exits because no specs were found
+    Can't run because no spec files were found.
+    We searched for any files matching this glob pattern:
+  */
+  // spec: []
+})


### PR DESCRIPTION
See test.js that crashes Cypress by passing `spec: {}` 