### PR TITLE
Add a failing test for iFrames

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -19,6 +19,8 @@ describe('page', () => {
 
     cy.getFrame('encryptedCardNumber')
       .find('#encryptedCardNumber')
-      .type(4242424242424242);
+      .type(4242424242424242)
+
+      .should('have.value', 4242424242424242);
   });
 })

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,6 +1,24 @@
+Cypress.Commands.add('getFrame', frame => {
+  // get the iframe > document > body
+  // and retry until the body element is not empty
+  return cy
+  .get(`[data-cse="${frame}"] iframe`)
+  .its('0.contentDocument.body').should('not.be.empty')
+  // wraps "body" DOM element to allow
+  // chaining more Cypress commands, like ".find(...)"
+  // https://on.cypress.io/wrap
+  .then(cy.wrap)
+});
+
 /// <reference types="cypress" />
 describe('page', () => {
   it('works', () => {
-    cy.visit('https://example.cypress.io')
-  })
+    cy.visit('/test')
+
+    .wait(1000)
+
+    cy.getFrame('encryptedCardNumber')
+      .find('#encryptedCardNumber')
+      .type(4242424242424242);
+  });
 })

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <input type="text" autofocus id="encryptedCardNumber"/>
+
+    <script>
+      document.querySelector('#encryptedCardNumber').focus();
+    </script>
+  </body>
+</html>

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    <input type="text" autofocus id="encryptedCardNumber"/>
+    <input type="text" id="encryptedCardNumber"/>
 
     <script>
       document.querySelector('#encryptedCardNumber').focus();

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <div data-cse="encryptedCardNumber">
+      <iframe src="iframe.html">
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
To test this, run these commands: 

```
npm install
npm run cypress:open
```

Then choose the `integration/spec.js` test, begin the test, and immediately click your cursor on your desktop, so the window is blurred. (This last part is essential to being able to reproduce; if I knew of a way to programmatically do this, I've give the steps for it). The result is this failing test:

<img width="765" alt="Screen Shot 2020-07-28 at 4 35 11 PM" src="https://user-images.githubusercontent.com/1827628/88726661-c17c4a80-d0f3-11ea-9e95-2076f8548d30.png">

The reason this bug is happening is because this auto-focus occurs: 

https://github.com/martynchamberlin/cypress-test-tiny/blob/1fea93a4c994e75d20c50689c1e88c07c5f8a46a/test/iframe.html#L6

If you were to remove that line, the test would pass. I'll be putting together a Pull Request in the main repo for Cypress that proposes a solution that gets this working for me. 