### PR TITLE
chore(ci): add CACHE_VERSION to cache key

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,9 +42,9 @@ jobs:
       # Download and cache dependencies for the app and for tests
       - restore_cache:
           keys:
-            - dependencies-v2-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+            - v{{ .Environment.CACHE_VERSION }}-dependencies-v2-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
-            - dependencies-v2-{{ arch }}-{{ .Branch }}-
+            - v{{ .Environment.CACHE_VERSION }}-dependencies-v2-{{ arch }}-{{ .Branch }}-
 
       - run: npm ci
       - run: npm install @cypress/commit-message-install
@@ -59,7 +59,7 @@ jobs:
             - ~/.npm
             # Cypress binary (or yarn dependencies) on Linux
             - ~/Library/Caches/Cypress
-          key: dependencies-v2-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v{{ .Environment.CACHE_VERSION }}-dependencies-v2-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
       - run: $(npm bin)/commit-message-install --else "npm install cypress"
       - run: $(npm bin)/run-if npm run cypress:info
@@ -94,9 +94,9 @@ jobs:
       # Download and cache dependencies for the app and for tests
       - restore_cache:
           keys:
-            - dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+            - v{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
-            - dependencies-{{ arch }}-{{ .Branch }}-
+            - v{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{ .Branch }}-
 
       - run: npm ci
 
@@ -108,7 +108,7 @@ jobs:
             - ~/.npm
             # Cypress binary (or yarn dependencies) on Linux
             - ~/.cache
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
       - run: npm install @cypress/commit-message-install
       - run: $(npm bin)/commit-message-install --else "npm install cypress"
@@ -140,12 +140,12 @@ jobs:
           substring: Testing new darwin
 
       - restore_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
       - run: npm ci
 
       - save_cache:
-          key: dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             # could not use environment variables for some reason
             - C:\Users\circleci\AppData\Local\Cypress\Cache


### PR DESCRIPTION
Need to break the cache, since it looks like the `darwin` cache in `master` has gotten corrupted somehow: https://app.circleci.com/pipelines/github/cypress-io/cypress-test-tiny/6855/workflows/8c47ddca-e737-4368-8990-5e3141d0bec6/jobs/18757