### PR TITLE
chore: add cypress/downloads to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 mochawesome-report/
 node_modules/
 report/
-cypress/videos
 .DS_Store
+
+# Temporary Cypress files
+cypress/downloads
 cypress/screenshots
+cypress/videos


### PR DESCRIPTION
This PR adds the default value of `cypress/downloads` to [.gitignore](https://github.com/cypress-io/cypress-test-tiny/blob/master/.gitignore). 

See Cypress documentation [Configuration > Folders / Files](https://docs.cypress.io/guides/references/configuration) which describes the `downloadsFolder` option with the default value of `cypress/downloads` and description "Path to folder where files downloaded during a test are saved."