### PR TITLE
chore: update xcode and resource class to gen2 macOS executor

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,8 @@ orbs:
 executors:
   mac:
     macos:
-      xcode: "14.0.1"
+      xcode: "14.3.1"
+    resource_class: macos.x86.medium.gen2
 
 jobs:
   mac-test:


### PR DESCRIPTION
update circleCI macOS runner to gen2 as gen1 is being removed on October 2nd