### PR TITLE
chore: Update circle.yml to use m1 resource class

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ executors:
   mac:
     macos:
       xcode: "14.3.1"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
 
 jobs:
   mac-test:


### PR DESCRIPTION
Brownout today that highlighted the deprecated resource class is in use: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718